### PR TITLE
Fixed verify.ps1 breaking builds in other projects

### DIFF
--- a/HearthDb/HearthDb.csproj
+++ b/HearthDb/HearthDb.csproj
@@ -90,7 +90,7 @@
   git clone --depth=1 https://github.com/HearthSim/hsdata.git "$(ProjectDir)hsdata"
 )
 if "$(ConfigurationName)" == "Release" (
-  powershell -ExecutionPolicy Unrestricted -file "$(ProjectDir)verify.ps1" "$(ProjectDir)"
+  powershell -ExecutionPolicy Unrestricted -file "$(ProjectDir)verify.ps1" $(ProjectDir)
 )
 xcopy /Y "$(ProjectDir)hsdata\CardDefs.xml" "$(ProjectDir)CardDefs.xml*"</PreBuildEvent>
   </PropertyGroup>


### PR DESCRIPTION
This was breaking the build of another project I was working on, Hearthstone Collection Tracker. For some reason the quotes are causing the argument to not pass correctly when the project is being referenced in another project in the same solution.

I tested this both in the other solution and in the main HearthDb solution, and it works in both cases and passes the argument correctly.

For reference, this was the error the build was receiving:

Get-Content : Cannot find path 'C:\projects\hearthstone-collection-tracker\Hear
  thDb\HearthDb"Properties\AssemblyInfo.cs' because it does not exist.
  At C:\projects\hearthstone-collection-tracker\HearthDb\HearthDb\verify.ps1:1 
  char:20