### PR TITLE
Parse power with list

### DIFF
--- a/HearthDb/CardDefs/Entity.cs
+++ b/HearthDb/CardDefs/Entity.cs
@@ -31,7 +31,7 @@ namespace HearthDb.CardDefs
 		public List<Tag> ReferencedTags { get; set; } = new List<Tag>();
 
 		[XmlElement("Power")]
-		public Power Power { get; set; }
+		public List<Power> Powers { get; set; }
 
 		[XmlElement("EntourageCard")]
 		public List<EntourageCard> EntourageCards { get; set; } = new List<EntourageCard>();


### PR DESCRIPTION
**Currently an entity contains multiple power node**s, and the  previous code will only parse first power node,  and it parsed Cloud Prince first power node without play requirement.

Murkspark Eel
```xml
<Power definition="00000012-3781-4b7f-bb1d-fd54f645afe9">
  <PlayRequirement param="" reqID="75"/>
</Power>
<Power definition="00000012-afaa-4788-aca3-9629d2d246d6"/>
```
		
Cloud Prince
```xml
<Power definition="cabafd80-a4fc-474a-9b91-b9f36fe14d7d"/>
<Power definition="00000012-be43-4d77-8780-0d77d38da392">
  <PlayRequirement param="1" reqID="59"/>
</Power>
```